### PR TITLE
[release] v0.2.1

### DIFF
--- a/entrypoints/options/index.tsx
+++ b/entrypoints/options/index.tsx
@@ -157,7 +157,7 @@ function IndexOptions() {
       </div>
 
       <div className="options-footer">
-        <p className="version-info">DeepWiki++ v0.2.0</p>
+        <p className="version-info">DeepWiki++ v0.2.1</p>
         <p className="usage-info">
           The extension will switch between these hosts when you click the
           switch button in the popup.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "wakishi",
   "description": "Enhanced browsing tool for DeepWiki",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   manifest: {
     name: "DeepWiki++",
-    version: "0.2.0",
+    version: "0.2.1",
     description: "Enhanced browsing tool for DeepWiki",
     permissions: ["tabs", "storage", "activeTab"],
     host_permissions: ["https://github.com/*", "https://deepwiki.com/*"],


### PR DESCRIPTION
This pull request updates the version of the DeepWiki++ extension from `0.2.0` to `0.2.1` across various files to reflect a new release.

Version update changes:

* [`entrypoints/options/index.tsx`](diffhunk://#diff-c0472fd8ab196dd8fb97ff072f71138bbbdbdb4ff001c7bcdb6e984e28c24a2fL160-R160): Updated the displayed version in the footer from `v0.2.0` to `v0.2.1`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): Updated the `version` field from `0.2.0` to `0.2.1`.
* [`wxt.config.ts`](diffhunk://#diff-09c55dc0ee48c836f078cf65fe7253e1713e78ed1aea44735a987bc581223766L11-R11): Updated the `version` field in the manifest configuration from `0.2.0` to `0.2.1`.