### PR TITLE
[fix] Remove matching patterns for the content script | localhost and any other hosts

### DIFF
--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -3,18 +3,7 @@ import { isHeadingSection } from "../../domain/heading-collection/heading-sectio
 import { AddHeadingSectionMessage } from "../../shared/messaging";
 
 export default defineContentScript({
-  matches: [
-    "https://deepwiki.com/*",
-    "https://*.deepwiki.com/*",
-    "https://deepwiki.corp/*",
-    "https://*.deepwiki.corp/*",
-    "https://wiki.corp/*",
-    "https://*.wiki.corp/*",
-    // Development/test patterns
-    "file://*/*", // Allow local files for testing
-    "http://localhost:*/*", // Allow local development server
-    "https://localhost:*/*", // Allow local development server with HTTPS
-  ],
+  matches: ["https://deepwiki.com/*"],
   main() {
     console.log("DeepWiki++: Content script loaded on DeepWiki");
 


### PR DESCRIPTION
This pull request simplifies the `matches` configuration in the `entrypoints/content/index.ts` file by restricting the content script to only run on the primary `https://deepwiki.com/*` domain. 

Key change:

* [`entrypoints/content/index.ts`](diffhunk://#diff-22e78ddb617c02afbd3e8e0aecf6de92cc4a8deaf92183ead2cc4cbea9c9ff7bL6-R6): Removed additional URL patterns from the `matches` array, including subdomains, corporate domains, and development/test patterns, leaving only `https://deepwiki.com/*`. This restricts the content script to the main DeepWiki domain.