### PR TITLE
[release] v0.2.2

### DIFF
--- a/entrypoints/options/index.tsx
+++ b/entrypoints/options/index.tsx
@@ -157,7 +157,7 @@ function IndexOptions() {
       </div>
 
       <div className="options-footer">
-        <p className="version-info">DeepWiki++ v0.2.1</p>
+        <p className="version-info">DeepWiki++ v0.2.2</p>
         <p className="usage-info">
           The extension will switch between these hosts when you click the
           switch button in the popup.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "wakishi",
   "description": "Enhanced browsing tool for DeepWiki",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   manifest: {
     name: "DeepWiki++",
-    version: "0.2.1",
+    version: "0.2.2",
     description: "Enhanced browsing tool for DeepWiki",
     permissions: ["tabs", "storage", "activeTab"],
     host_permissions: ["https://github.com/*", "https://deepwiki.com/*"],


### PR DESCRIPTION
This pull request updates the version of the DeepWiki++ extension from `0.2.1` to `0.2.2` across various files to reflect a new release.

Version updates:

* Updated the version displayed in the footer of the options page from `0.2.1` to `0.2.2` in `entrypoints/options/index.tsx`.
* Updated the version field in `package.json` from `0.2.1` to `0.2.2`.
* Updated the version in the `manifest` configuration in `wxt.config.ts` from `0.2.1` to `0.2.2`.