### PR TITLE
[fix] Modify overflow content in sidepanel

### DIFF
--- a/entrypoints/sidepanel/style.css
+++ b/entrypoints/sidepanel/style.css
@@ -197,10 +197,15 @@
 
 .section-title-container {
   flex: 1;
+  min-width: 0; /* Enable flex item to shrink below its content size */
+  overflow: hidden; /* Hide overflowing content */
 }
 
 .section-title {
   margin: 0 0 4px 0;
+  overflow: hidden; /* Hide overflowing content */
+  text-overflow: ellipsis; /* Show ellipsis for truncated text */
+  white-space: nowrap; /* Prevent line breaks */
 }
 
 .section-title-h1 {


### PR DESCRIPTION
This pull request makes improvements to the styling of section titles in the side panel to enhance layout flexibility and text truncation behavior. 

Styling improvements:

* [`entrypoints/sidepanel/style.css`](diffhunk://#diff-e1f371c5bcf7ef52774a2bb87fa06e183718d9a158ec3adf6ce11fc2301a04d9R200-R208): Updated `.section-title-container` to allow it to shrink below its content size (`min-width: 0`) and hide overflowing content (`overflow: hidden`).
* [`entrypoints/sidepanel/style.css`](diffhunk://#diff-e1f371c5bcf7ef52774a2bb87fa06e183718d9a158ec3adf6ce11fc2301a04d9R200-R208): Enhanced `.section-title` to handle long text gracefully by hiding overflow (`overflow: hidden`), adding ellipsis for truncated text (`text-overflow: ellipsis`), and preventing line breaks (`white-space: nowrap`).